### PR TITLE
Import most of joiner.rb from 18F/hub

### DIFF
--- a/lib/team_hub/joiner.rb
+++ b/lib/team_hub/joiner.rb
@@ -1,0 +1,238 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2014 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require 'hash-joiner'
+require 'team_hub/private_assets'
+require 'weekly_snippets/version'
+
+module TeamHub
+
+  # Joins the data from +_data+, +_data/public+, and +_data/private+ into
+  # +site.data+, making the data look as though it came from a single source.
+  # Also filters out private data when +site.config[+'public'] is +true+ (aka
+  # "public mode").
+  class Joiner
+    attr_reader :site, :data, :public_mode, :team_by_email, :source
+
+    # Used to standardize snippet data of different versions before joining
+    # and publishing.
+    SNIPPET_VERSIONS = {
+      'v1' => ::WeeklySnippets::Version.new(
+        version_name:'v1',
+        field_map:{
+          'Username' => 'username',
+          'Timestamp' => 'timestamp',
+          'Name' => 'full_name',
+          'Snippets' => 'last-week',
+          'No This Week' => 'this-week',
+        }
+      ),
+      'v2' => ::WeeklySnippets::Version.new(
+        version_name:'v2',
+        field_map:{
+          'Timestamp' => 'timestamp',
+          'Public vs. Private' => 'public',
+          'Last Week' => 'last-week',
+          'This Week' => 'this-week',
+          'Username' => 'username',
+        },
+        markdown_supported: true
+      ),
+      'v3' => ::WeeklySnippets::Version.new(
+        version_name:'v3',
+        field_map:{
+          'Timestamp' => 'timestamp',
+          'Public' => 'public',
+          'Username' => 'username',
+          'Last week' => 'last-week',
+          'This week' => 'this-week',
+        },
+        public_field: 'public',
+        public_value: 'Public',
+        markdown_supported: true
+      ),
+    }
+
+    # +site+:: Jekyll site data object
+    def initialize(site)
+      @site = site
+      @data = site.data
+      @public_mode = site.config['public']
+
+      if (site.data['private'] || {}).empty?
+        @source = 'public'
+        @join_source = @data
+      else
+        @source = 'private'
+        @join_source = site.data['private']
+      end
+
+      # We'll always need a 'team' property.
+      @join_source['team'] ||= []
+      ['team', 'projects', 'departments', 'working_groups'].each do |c|
+        i = @join_source[c]
+        @join_source[c] = Joiner.flatten_index(i) if i.instance_of? Hash
+      end
+      create_team_by_email_index
+    end
+
+    # Takes Hash<string, Array<Hash>> collections and flattens them into an
+    # Array<Hash>.
+    def self.flatten_index(index)
+      private_data = index['private']
+      index['private'] = {'private' => private_data.values} if private_data
+      index.values
+    end
+
+    # Joins public and private project data.
+    def join_project_data
+      promote_private_data 'projects'
+
+      if @public_mode
+        @data['projects'].delete_if {|p| p['status'] == 'Hold'}
+      end
+    end
+
+    # Creates +self.team_by_email+, a hash of email address => username to use
+    # as an index into +site.data[+'team'] when joining snippet data.
+    #
+    # MUST be called before remove_data, or else private email addresses will
+    # be inaccessible and snippets will not be joined.
+    def create_team_by_email_index
+      @team_by_email = self.class.create_team_by_email_index(
+        @join_source['team'])
+    end
+
+    # Creates an index of team member information keyed by email address.
+    # @param team [Array<Hash>] contains individual team member information
+    # @return [Hash<String, Hash>] email address => team member
+    def self.create_team_by_email_index(team)
+      team_by_email = {}
+      team.each do |i|
+        # A Hash containing only a 'private' property is a list of team
+        # members whose information is completely private.
+        if i.keys == ['private']
+          i['private'].each do |private_member|
+            email = private_member['email']
+            team_by_email[email] = private_member['name'] if email
+          end
+        else
+          email = i['email']
+          email = i['private']['email'] if !email and i.member? 'private'
+          team_by_email[email] = i['name'] if email
+        end
+      end
+      team_by_email
+    end
+
+    # Prepares +site.data[@source]+ prior to joining its data with
+    # +site.data+. All data nested within +'private'+ attributes will be
+    # stripped when @public_mode is +true+, and will be promoted to the same
+    # level as its parent when @public_mode is +false+.
+    #
+    # If a block is given, +site.data[@source]+ will be passed to the block
+    # for other initialization/setup.
+    def setup_join_source
+      if @public_mode
+        HashJoiner.remove_data @join_source, 'private'
+      else
+        HashJoiner.promote_data @join_source, 'private'
+      end
+      yield @join_source if block_given?
+    end
+
+    # Promote data from +site.data['private']+ into +site.data+, if
+    # +site.data['private']+ exists.
+    # +category+:: key into +site.data['private']+ specifying data collection
+    def promote_private_data(category)
+      @data[category] = @join_source[category] if @join_source != @data
+    end
+
+    # Assigns the +image+ property of each team member based on the team
+    # member's username and whether or not an image asset exists for that team
+    # member. +site.config[+'missing_team_member_img'] is used as the default
+    # when no image asset is available.
+    def assign_team_member_images
+      base = @site.source
+      img_dir = site.config['team_img_dir']
+      missing = File.join(img_dir, site.config['missing_team_member_img'])
+
+      site.data['team'].each do |member|
+        img = File.join(img_dir, "#{member['name']}.jpg")
+
+        if (File.exists? File.join(base, img) or
+            ::TeamHub::PrivateAssets.exists?(site, img))
+          member['image'] = img
+        else
+          member['image'] = missing
+        end
+      end
+    end
+
+    # Joins snippet data into +site.data[+'snippets'] and filters out snippets
+    # from team members not appearing in +site.data[+'team'] or
+    # +team_by_email+.
+    #
+    # Snippet data is expected to be stored in files matching the pattern:
+    # +_data/+@source/snippets/[version]/[YYYYMMDD].csv
+    #
+    # resulting in the initial structure:
+    # +site.data[@source][snippets][version][YYYYMMDD] = Array<Hash>
+    #
+    # After this function returns, the new structure will be:
+    # +site.data[snippets][YYYYMMDD] = Array<Hash>
+    #
+    # and each individual snippet will have been converted to a standardized
+    # format defined by ::WeeklySnippets::Version.
+    def join_snippet_data(snippet_versions)
+      standardized = ::WeeklySnippets::Version.standardize_versions(
+        @join_source['snippets'], snippet_versions)
+      team = {}
+      @data['team'].each {|i| team[i['name']] = i}
+      result = {}
+      standardized.each do |timestamp, snippets|
+        joined = []
+        snippets.each do |snippet|
+          username = snippet['username']
+          member = team[username] || team[@team_by_email[username]]
+
+          if member
+            snippet['name'] = member['name']
+            snippet['full_name'] = member['full_name']
+            joined << snippet
+          end
+        end
+        result[timestamp] = joined unless joined.empty?
+      end
+      @data['snippets'] = result
+    end
+
+    # Imports the guest_users list into the top-level site.data object.
+    def import_guest_users
+      @data['guest_users'] = @join_source['hub']['guest_users']
+    end
+
+    # Filters out private pages when generating the public Hub.
+    def filter_private_pages
+      if @public_mode
+        private_pages_path = "/#{@site.config['private_pages_path']}"
+        @site.pages.delete_if do |p|
+          p.relative_path.start_with? private_pages_path
+        end
+      end
+    end
+  end
+end

--- a/lib/team_hub/version.rb
+++ b/lib/team_hub/version.rb
@@ -23,5 +23,5 @@
 #   https://github.com/18F/hub"
 
 module TeamHub
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/test/joiner_assign_team_member_images_test.rb
+++ b/test/joiner_assign_team_member_images_test.rb
@@ -1,0 +1,66 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2015 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../lib/team_hub/joiner"
+require_relative "site"
+
+require "minitest/autorun"
+require "test_temp_file_helper"
+
+module TeamHub
+  class AssignTeamMemberImagesTest < ::Minitest::Test
+    def setup
+      @temp_file_helper = ::TestTempFileHelper::TempFileHelper.new
+      @team_img_dir = File.join 'assets', 'images' ,'team'
+      @private_data_path = File.join '_data', 'private'
+      @missing_team_member_img = 'logo-18f.jpg'
+
+      @site = DummyTestSite.new(config:{
+        'source' => @temp_file_helper.tmpdir,
+        'team_img_dir' => @team_img_dir,
+        'private_data_path' => @private_data_path,
+        'missing_team_member_img' => @missing_team_member_img,
+      })
+
+      @member = {'name' => 'mbland'}
+      @member_image = "#{@member['name']}.jpg"
+      @site.data['team'] = [@member]
+
+      @joiner = Joiner.new @site
+    end
+
+    def test_member_without_image_file_gets_missing_team_member_img
+      @joiner.assign_team_member_images
+      assert_equal(File.join(@team_img_dir, @missing_team_member_img),
+        @member['image'])
+    end
+
+    def test_member_with_image_file
+      @temp_file_helper.mkfile(File.join @team_img_dir, @member_image)
+      @joiner.assign_team_member_images
+      assert_equal File.join(@team_img_dir, @member_image), @member['image']
+    end
+
+    def test_member_with_private_image_file
+      @temp_file_helper.mkfile(
+        File.join @private_data_path, @team_img_dir, @member_image)
+      @joiner.assign_team_member_images
+      assert_equal File.join(@team_img_dir, @member_image), @member['image']
+    end
+  end
+end
+

--- a/test/joiner_create_team_by_email_index_test.rb
+++ b/test/joiner_create_team_by_email_index_test.rb
@@ -1,0 +1,105 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2014 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../lib/team_hub/joiner"
+require_relative "site"
+
+require "minitest/autorun"
+
+module TeamHub
+  class CreateTeamByEmailIndexTest < ::Minitest::Test
+    def setup
+      @site = DummyTestSite.new
+      @team = []
+      @site.data['private'] = {'team' => @team}
+    end
+
+    def test_nonexistent_join_source
+      @site.data.delete 'private'
+      @site.data.delete 'public'
+      impl = Joiner.new(@site)
+      assert_equal 'public', impl.source
+      assert_empty impl.team_by_email
+    end
+
+    def test_nonexistent_team
+      @site.data.delete 'private'
+      impl = Joiner.new(@site)
+      assert_equal 'public', impl.source
+      assert_empty impl.team_by_email
+    end
+
+    def test_empty_team
+      impl = Joiner.new(@site)
+      assert_equal 'private', impl.source
+      assert_empty impl.team_by_email
+    end
+
+    def test_single_user_index
+      @team << {'name' => 'mbland', 'email' => 'michael.bland@gsa.gov'}
+      impl = Joiner.new(@site)
+      assert_equal({'michael.bland@gsa.gov' => 'mbland'}, impl.team_by_email)
+    end
+
+    def test_single_user_with_private_email_index
+      @team << {
+        'name' => 'mbland', 'private' => {'email' => 'michael.bland@gsa.gov'},
+      }
+      impl = Joiner.new(@site)
+      assert_equal({'michael.bland@gsa.gov' => 'mbland'}, impl.team_by_email)
+    end
+
+    def test_single_private_user_index
+      @team << {
+        'private' => [
+          {'name' => 'mbland', 'email' => 'michael.bland@gsa.gov'},
+        ],
+      }
+      impl = Joiner.new(@site)
+      assert_equal({'michael.bland@gsa.gov' => 'mbland'}, impl.team_by_email)
+    end
+
+    def test_multiple_user_index
+      @team << {'name' => 'mbland', 'email' => 'michael.bland@gsa.gov'}
+      @team << {
+        'name' => 'foobar', 'private' => {'email' => 'foo.bar@gsa.gov'},
+      }
+      @team << {
+        'private' => [
+          {'name' => 'bazquux', 'email' => 'baz.quux@gsa.gov'},
+        ],
+      }
+
+      expected = {
+        'michael.bland@gsa.gov' => 'mbland',
+        'foo.bar@gsa.gov' => 'foobar',
+        'baz.quux@gsa.gov' => 'bazquux',
+      }
+      impl = Joiner.new(@site)
+      assert_equal expected, impl.team_by_email
+    end
+
+    def test_ignore_users_without_email
+      @team << {'name' => 'mbland'}
+      @team << {'name' => 'foobar', 'private' => {}}
+      @team << {'private' => [{'name' => 'bazquux'}]}
+
+      impl = Joiner.new(@site)
+      assert_empty impl.team_by_email
+    end
+  end
+end

--- a/test/joiner_filter_private_pages_test.rb
+++ b/test/joiner_filter_private_pages_test.rb
@@ -1,0 +1,93 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2014 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../lib/team_hub/joiner"
+require_relative "page"
+require_relative "site"
+
+require "minitest/autorun"
+
+module TeamHub
+  class FilterPrivatePagesTest < ::Minitest::Test
+    def setup
+      @site = DummyTestSite.new
+      @site.config['private_pages_path'] = 'pages/private'
+      @all_page_names = []
+      @public_page_names = []
+    end
+
+    def add_public_page(filename)
+      @site.pages << DummyTestPage.new(@site, '/pages', filename)
+      @all_page_names << filename
+      @public_page_names << filename
+    end
+
+    def add_private_page(filename)
+      @site.pages << DummyTestPage.new(@site, '/pages/private', filename)
+      @all_page_names << filename
+    end
+
+    def filter_pages_in_internal_mode
+      @site.config.delete 'public'
+      Joiner.new(@site).filter_private_pages
+    end
+
+    def filter_pages_in_public_mode
+      @site.config['public'] = true
+      Joiner.new(@site).filter_private_pages
+    end
+
+    def page_names
+      @site.pages.map {|p| p.name}
+    end
+
+    def test_no_pages
+      filter_pages_in_internal_mode
+      assert_empty page_names
+      filter_pages_in_public_mode
+      assert_empty page_names
+    end
+
+    def test_single_public_page
+      add_public_page 'public.html'
+      filter_pages_in_internal_mode
+      assert_equal(@all_page_names, page_names)
+      filter_pages_in_public_mode
+      assert_equal(@public_page_names, page_names)
+    end
+
+    def test_single_private_page
+      add_private_page 'private.html'
+      filter_pages_in_internal_mode
+      assert_equal(@all_page_names, page_names)
+      filter_pages_in_public_mode
+      assert_empty page_names
+    end
+
+    def test_public_and_private_pages
+      add_private_page 'private-0.html'
+      add_public_page 'public-0.html'
+      add_private_page 'private-1.html'
+      add_public_page 'public-1.html'
+      add_private_page 'private-2.html'
+      filter_pages_in_internal_mode
+      assert_equal(@all_page_names, page_names)
+      filter_pages_in_public_mode
+      assert_equal(@public_page_names, page_names)
+    end
+  end
+end

--- a/test/joiner_flatten_index_test.rb
+++ b/test/joiner_flatten_index_test.rb
@@ -1,0 +1,55 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2015 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../lib/team_hub/joiner"
+
+require "minitest/autorun"
+
+module TeamHub
+  class FlattenIndexTest < ::Minitest::Test
+    def test_empty_index
+      assert_empty Joiner.flatten_index({})
+    end
+
+    def test_index
+      orig = {
+        'mbland' => {'name' => 'mbland'},
+        'afeld' => {'name' => 'afeld'},
+        'mhz' => {'name' => 'mhz'},
+      }
+      assert_equal(
+        [{'name' => 'mbland'}, {'name' => 'afeld'}, {'name' => 'mhz' }],
+        Joiner.flatten_index(orig))
+    end
+
+    def test_index_with_private_values
+      orig = {
+        'mbland' => {'name' => 'mbland'},
+        'afeld' => {'name' => 'afeld'},
+        'mhz' => {'name' => 'mhz'},
+        'private' => {
+          'gboone' => {'name' => 'gboone'},
+          'ekamlley' => {'name' => 'ekamlley'},
+        },
+      }
+      assert_equal(
+        [{'name' => 'mbland'}, {'name' => 'afeld'}, {'name' => 'mhz' },
+         {'private' => [{'name' => 'gboone'}, {'name' => 'ekamlley'}]}],
+        Joiner.flatten_index(orig))
+    end
+  end
+end

--- a/test/joiner_import_guest_users_test.rb
+++ b/test/joiner_import_guest_users_test.rb
@@ -1,0 +1,66 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2014 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../lib/team_hub/joiner"
+require_relative "site"
+
+require "minitest/autorun"
+
+module TeamHub
+  class ImportGuestUsersTest < ::Minitest::Test
+    def setup
+      @site = DummyTestSite.new
+      @site.data.delete 'private'
+    end
+
+    def new_impl
+      impl = Joiner.new(@site)
+      impl.setup_join_source do |join_source|
+        ::HashJoiner.assign_empty_defaults(join_source,
+          [], ['hub'], [])
+        ::HashJoiner.assign_empty_defaults(join_source['hub'],
+          ['guest_users'], [], [])
+      end
+      impl
+    end
+
+    def test_no_private_data
+      assert_empty new_impl.import_guest_users
+    end
+
+    def test_no_hub_data
+      assert_empty new_impl.import_guest_users
+      assert_empty @site.data['guest_users']
+    end
+
+    def test_no_guest_users
+      @site.data['private'] = {'hub' => {}}
+      assert_empty new_impl.import_guest_users
+      assert_empty @site.data['guest_users']
+    end
+
+    def test_guest_users_moved_to_top_level
+      guests = [
+        {'email' => 'michael.bland@gsa.gov',
+         'full_name' => 'Mike Bland'},
+        ]
+      @site.data['private'] = {'hub' => {'guest_users' => guests}}
+      assert_equal guests, new_impl.import_guest_users
+      assert_equal guests, @site.data['guest_users']
+    end
+  end
+end

--- a/test/joiner_join_project_data_test.rb
+++ b/test/joiner_join_project_data_test.rb
@@ -1,0 +1,47 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2014 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../lib/team_hub/joiner"
+require_relative "site"
+
+require "minitest/autorun"
+
+module TeamHub
+  class JoinProjectDataTest < ::Minitest::Test
+    def setup
+      @site = DummyTestSite.new
+      @site.data['private']['team'] = {}
+      @site.data['private']['projects'] = [
+        {'name' => 'MSB-USA', 'status' => 'Hold'}
+      ]
+    end
+
+    def test_join_project
+      @impl = Joiner.new(@site)
+      @impl.join_project_data
+      assert_equal([{'name' => 'MSB-USA', 'status' => 'Hold'}],
+        @site.data['projects'])
+    end
+
+    def test_hide_hold_projects_in_public_mode
+      @site.config['public'] = true
+      @impl = Joiner.new(@site)
+      @impl.join_project_data
+      assert_empty @site.data['projects']
+    end
+  end
+end

--- a/test/joiner_join_snippet_data_test.rb
+++ b/test/joiner_join_snippet_data_test.rb
@@ -1,0 +1,157 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2014 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../lib/team_hub/joiner"
+require_relative "site"
+
+require "minitest/autorun"
+require "weekly_snippets/version"
+
+module TeamHub
+  class JoinSnippetDataTest < ::Minitest::Test
+    def setup
+      @site = DummyTestSite.new
+      @site.data['private']['snippets'] = {'v1' => {}, 'v2' => {}, 'v3' => {}}
+      @site.data['private']['team'] = []
+      @impl = Joiner.new(@site)
+      @expected = {}
+    end
+
+    def set_team(team_list)
+      @site.data['private']['team'] = team_list
+      @impl.create_team_by_email_index
+      @impl.promote_private_data 'team'
+    end
+
+    def add_snippet(version, timestamp, name, full_name,
+      email, public_or_private, last_week, this_week, expected: true)
+      snippets = @site.data['private']['snippets'][version]
+      unless snippets.member? timestamp
+        snippets[timestamp] = []
+      end
+      collection = snippets[timestamp]
+
+      case version
+      when "v1"
+        collection << {
+          'Timestamp' => timestamp,
+          'Username' => email,
+          'Name' => full_name,
+          'Snippets' => last_week
+        }
+      when "v2"
+        unless ['Private', ''].include? public_or_private
+          raise Exception.new("Invalide public_or_private for v2: "+
+            "#{public_or_private}")
+        end
+        collection << {
+          'Timestamp' => timestamp,
+          'Public vs. Private' => public_or_private,
+          'Last Week' => last_week,
+          'This Week' => this_week,
+          'Username' => email,
+        }
+      when "v3"
+        unless ['Public', ''].include? public_or_private
+          raise Exception.new("Invalide public_or_private for v3: "+
+            "#{public_or_private}")
+        end
+        collection << {
+          'Timestamp' => timestamp,
+          'Public' => public_or_private,
+          'Username' => email,
+          'Last week' => last_week,
+          'This week' => this_week,
+        }
+      else
+        raise Exception.new "Unknown version: #{version}"
+      end
+
+      if expected
+        s = {}.merge collection.last
+        Joiner::SNIPPET_VERSIONS[version].standardize s
+        s['name'] = name
+        s['full_name'] = full_name
+        @expected[timestamp] = [] unless @expected.member? timestamp
+        @expected[timestamp] << s
+      end
+    end
+
+    def test_empty_snippet_data
+      set_team([])
+      @impl.join_snippet_data Joiner::SNIPPET_VERSIONS
+      assert_empty @site.data['snippets']
+    end
+
+    def test_raise_if_snippet_version_unknown
+      set_team([])
+      add_snippet('v1', '20141218', 'mbland', 'Mike Bland',
+        'michael.bland@gsa.gov', 'unused', '- Did stuff', '')
+      error = assert_raises ::WeeklySnippets::Version::UnknownVersionError do
+        @impl.join_snippet_data({})
+      end
+      assert_equal "Unknown snippet version: v1", error.to_s
+    end
+
+    def test_joined_snippets_are_empty_if_no_team
+      set_team([])
+      add_snippet('v1', '20141218', 'mbland', 'Mike Bland',
+        'michael.bland@gsa.gov', 'unused', '- Did stuff', '',
+        expected:false)
+      add_snippet('v2', '20141225', 'mbland', 'Mike Bland',
+        'michael.bland@gsa.gov', '', '- Did stuff', '', expected:false)
+      add_snippet('v3', '20141231', 'mbland', 'Mike Bland',
+        'michael.bland@gsa.gov', 'Public', '- Did stuff', '', expected:false)
+      @impl.join_snippet_data Joiner::SNIPPET_VERSIONS
+      assert_empty @site.data['snippets']
+    end
+
+    def test_join_all_snippets
+      set_team([
+        {'name' => 'mbland', 'full_name' => 'Mike Bland',
+         'email' => 'michael.bland@gsa.gov'},
+      ])
+      add_snippet('v1', '20141218', 'mbland', 'Mike Bland',
+        'michael.bland@gsa.gov', 'unused', '- Did stuff', '')
+      add_snippet('v2', '20141225', 'mbland', 'Mike Bland',
+        'michael.bland@gsa.gov', '', '- Did stuff', '')
+      add_snippet('v3', '20141231', 'mbland', 'Mike Bland',
+        'michael.bland@gsa.gov', 'Public', '- Did stuff', '')
+      @impl.join_snippet_data Joiner::SNIPPET_VERSIONS
+      assert_equal @expected, @site.data['snippets']
+    end
+
+    # This tests the case where we're publishing snippets imported into
+    # _data/public using _data/import-public.rb. That script will substitute
+    # the original snippets' email usernames with the corresponding Hub
+    # username.
+    def test_join_snippets_with_hub_username_instead_of_email_address
+      @site.config['public'] = true
+      @impl = Joiner.new(@site)
+
+      set_team([
+        {'name' => 'mbland', 'full_name' => 'Mike Bland',
+         'email' => 'michael.bland@gsa.gov'},
+      ])
+      add_snippet('v3', '20141231', 'mbland', 'Mike Bland', 'mbland',
+        'Public', '- Did stuff', '')
+
+      @impl.join_snippet_data Joiner::SNIPPET_VERSIONS
+      assert_equal @expected, @site.data['snippets']
+    end
+  end
+end

--- a/test/joiner_promote_private_data_test.rb
+++ b/test/joiner_promote_private_data_test.rb
@@ -1,0 +1,55 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2014 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../lib/team_hub/joiner"
+require_relative "site"
+
+require "minitest/autorun"
+
+module TeamHub
+  class PromotePrivateDataTest < ::Minitest::Test
+    def setup
+      @site = DummyTestSite.new
+    end
+
+    def test_no_impact_if_source_is_not_private
+      @site.data['team'] = [
+        {'name' => 'mbland', 'full_name' => 'Mike Bland',
+         'email' => 'michael.bland@gsa.gov'},
+      ]
+      impl = Joiner.new(@site)
+      impl.promote_private_data 'team'
+      assert_equal(
+        [{'name' => 'mbland', 'full_name' => 'Mike Bland',
+          'email' => 'michael.bland@gsa.gov'}],
+        @site.data['team'])
+    end
+
+    def test_promote_team_data_from_private_source
+      @site.data['private']['team'] = [
+        {'name' => 'mbland', 'full_name' => 'Mike Bland',
+         'email' => 'michael.bland@gsa.gov'},
+      ]
+      impl = Joiner.new(@site)
+      impl.promote_private_data 'team'
+      assert_equal(
+        [{'name' => 'mbland', 'full_name' => 'Mike Bland',
+          'email' => 'michael.bland@gsa.gov'}],
+        @site.data['team'])
+    end
+  end
+end

--- a/test/joiner_select_join_source_test.rb
+++ b/test/joiner_select_join_source_test.rb
@@ -1,0 +1,41 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2014 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../lib/team_hub/joiner"
+require_relative "site"
+
+require "minitest/autorun"
+
+module TeamHub
+  class SelectJoinSourceTest < ::Minitest::Test
+    def setup
+      @site = DummyTestSite.new
+    end
+
+    def test_select_private_source
+      @site.data['private']['sample_source_content'] = 'has private data'
+      impl = Joiner.new @site
+      assert_equal 'private', impl.source
+    end
+
+    def test_select_public_source
+      @site.data.delete 'private'
+      impl = Joiner.new @site
+      assert_equal 'public', impl.source
+    end
+  end
+end

--- a/test/joiner_setup_join_source_test.rb
+++ b/test/joiner_setup_join_source_test.rb
@@ -1,0 +1,81 @@
+# team_hub - Components for creating a team Hub using Jekyll
+#
+# Written in 2014 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../lib/team_hub/joiner"
+require_relative "site"
+
+require "hash-joiner"
+require "minitest/autorun"
+
+module TeamHub
+  class SetupJoinSourceTest < ::Minitest::Test
+    def setup
+      @site = DummyTestSite.new
+      @site.data['private']['team'] = [
+        {'name' => 'mbland', 'full_name' => 'Mike Bland',
+         'private' => {'email' => 'michael.bland@gsa.gov'}
+        },
+        {'private' => [
+          {'name' => 'foobar', 'full_name' => 'Foo Bar'},
+          ],
+        },
+      ]
+    end
+
+    def test_remove_private_data
+      @site.config['public'] = true
+      impl = Joiner.new(@site)
+      impl.setup_join_source
+      assert_equal(
+        [{'name' => 'mbland', 'full_name' => 'Mike Bland'}],
+        @site.data['private']['team'])
+    end
+
+    def test_promote_private_data
+      impl = Joiner.new(@site)
+      impl.setup_join_source
+      assert_equal(
+        [{'name' => 'mbland', 'full_name' => 'Mike Bland',
+          'email' => 'michael.bland@gsa.gov',
+         },
+         {'name' => 'foobar', 'full_name' => 'Foo Bar'},
+        ],
+        @site.data['private']['team'])
+    end
+
+    def test_process_data_using_block
+      impl = Joiner.new(@site)
+      impl.setup_join_source do |join_source|
+        ::HashJoiner.assign_empty_defaults(join_source['team'],
+          ['working_groups', 'projects'], [], ['email'])
+      end
+
+      assert_equal(
+        [{'name' => 'mbland', 'full_name' => 'Mike Bland',
+          'email' => 'michael.bland@gsa.gov',
+          'working_groups' => [], 'projects' => [],
+         },
+         {'name' => 'foobar', 'full_name' => 'Foo Bar',
+          'email' => '',
+          'working_groups' => [], 'projects' => [],
+         },
+        ],
+        @site.data['private']['team'])
+    end
+
+  end
+end

--- a/test/page.rb
+++ b/test/page.rb
@@ -1,6 +1,6 @@
 # team_hub - Components for creating a team Hub using Jekyll
 #
-# Written in 2015 by Mike Bland (michael.bland@gsa.gov)
+# Written in 2014 by Mike Bland (michael.bland@gsa.gov)
 # on behalf of the 18F team, part of the US General Services Administration:
 # https://18f.gsa.gov/
 #
@@ -14,9 +14,16 @@
 #
 # @author Mike Bland (michael.bland@gsa.gov)
 
-require 'team_hub/canonicalizer'
-require 'team_hub/cross_referencer'
-require 'team_hub/joiner'
-require 'team_hub/version'
-require 'team_hub/page'
-require 'team_hub/private_assets'
+require "jekyll"
+require "jekyll/page"
+
+module TeamHub
+  class DummyTestPage < ::Jekyll::Page
+    def initialize(site, dir, filename)
+      @site = site
+      @base = 'fake_test_basedir'
+      @dir = dir
+      @name = filename
+    end
+  end
+end


### PR DESCRIPTION
cc: @afeld

@gboone the `Joiner.flatten_index` function is the one I mentioned might be used to import all of the individual project/team member YAML files without requiring an explicit import step. It will render those files internally as `Array<Hash>` instances just like the all-in-one `projects.yml` and `team.yml` files.
